### PR TITLE
Implemented draw_score() function

### DIFF
--- a/src/logic/field.rs
+++ b/src/logic/field.rs
@@ -6,7 +6,7 @@ use logic::field::rand::distributions::IndependentSample;
 
 #[derive(Copy, Debug)]
 pub enum Direction {
-    LEFT, RIGHT, UP, DOWN
+    Left, Right, Up, Down
 }
 
 impl Clone for Direction {
@@ -137,10 +137,10 @@ impl<T:Clone> Field<T> {
 
         let (move_ok, score) = match dir {
 
-            Some(Direction::LEFT) => self.snake.move_left(self.width as i32, self.height as i32),
-            Some(Direction::RIGHT) => self.snake.move_right(self.width as i32, self.height as i32),
-            Some(Direction::UP) => self.snake.move_up(self.width as i32, self.height as i32),
-            Some(Direction::DOWN) => self.snake.move_down(self.width as i32, self.height as i32),
+            Some(Direction::Left) => self.snake.move_left(self.width as i32, self.height as i32),
+            Some(Direction::Right) => self.snake.move_right(self.width as i32, self.height as i32),
+            Some(Direction::Up) => self.snake.move_up(self.width as i32, self.height as i32),
+            Some(Direction::Down) => self.snake.move_down(self.width as i32, self.height as i32),
             None => self.snake.move_last(self.width as i32, self.height as i32),
         };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@ extern crate crossterm;
 
 use std::{thread, time};
 use std::collections::LinkedList;
-use std::sync::{Arc, Mutex};
 
 use crossterm::*;
 
@@ -15,7 +14,6 @@ struct Bounds {
     col: u16,
     row: u16
 }
-
 
 struct Term {
     cursor: TerminalCursor,
@@ -86,6 +84,7 @@ fn main() {
             None => { if dir.is_some() { end = true; } }
         }
     }
+    draw_score(&mut term);
 
     term.cursor.show().unwrap();
     RawScreen::disable_raw_mode().unwrap();
@@ -147,4 +146,35 @@ fn init(term: &mut Term) -> Bounds {
     };
 
     return bounds
+}
+
+fn draw_score(term: &mut Term) {
+    term.terminal.clear(ClearType::All);
+
+    const margin: (u16, u16) = (4, 4);
+    const height: u16 = 6;
+
+    let lineLen = term.terminal.terminal_size().0 - margin.0;
+    let mut line = String::from("*");
+
+    for _ in 0..lineLen {
+        line += "*";
+    }
+    let goto = term.cursor.goto(margin.0 / 2, margin.1 / 2);
+    
+    if goto.is_ok() {
+        print!("{}", line);
+    }
+
+    for n in 0..height {
+        let goto = term.cursor.goto(margin.0 / 2, margin.1 / 2 + n);
+        if goto.is_ok() {
+            print!("{}", "*");
+        }
+    }
+    println!();
+    
+    term.cursor.move_right(margin.0 / 2);
+    print!("{}", line);
+    
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,13 +57,15 @@ fn main() {
 
     let mut last: Option<Direction> = None;
 
+    let stdin = &mut term.input.read_async();
+
     while !end
     {
         let speed: u64 = 200 - score as u64 * 2;
         let speed: u64 = if speed < 150 {150} else {speed};
         thread::sleep(time::Duration::from_millis(speed));
 
-        let mut dir = read_direction(&mut term.input.read_async());
+        let mut dir = read_direction(stdin);
 
         if dir.is_some() {
             last = dir.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,7 @@ fn main() {
             None => { if dir.is_some() { end = true; } }
         }
     }
-    draw_score(&mut term);
+    draw_score(&mut term, score);
 
     term.cursor.show().unwrap();
     RawScreen::disable_raw_mode().unwrap();
@@ -148,31 +148,58 @@ fn init(term: &mut Term) -> Bounds {
     bounds
 }
 
-fn draw_score(term: &mut Term) {
+fn draw_score(term: &mut Term, score: u32) {
     term.terminal.clear(ClearType::All);
 
+    // the margin around the box (x, y).
     const margin: (u16, u16) = (4, 4);
+    // the height of the box.
     const height: u16 = 6;
 
+    // the length of the upper border.
     let lineLen = term.terminal.terminal_size().0 - margin.0;
     let mut line = String::from("*");
 
+    // build the upper border with the specified length.
     for _ in 0..lineLen {
         line += "*";
     }
     let goto = term.cursor.goto(margin.0 / 2, margin.1 / 2);
     
+    // draw the upper border.
     if goto.is_ok() {
         print!("{}", line);
     }
 
-    for n in 0..height {
-        let goto = term.cursor.goto(margin.0 / 2, margin.1 / 2 + n);
+    let title = String::from("GAME OVER!");
+    let text = format!("Your Score: {}", score);
+
+    for n in 0..height + 1 {
+        let x = margin.0 / 2;
+        let y = margin.1 / 2 + n;
+        let goto = term.cursor.goto(x, y);
         
         if goto.is_ok() {
             print!("{}", "*");
         }
-        let goto = term.cursor.goto((margin.0 / 2) + lineLen, margin.1 / 2 + n);
+
+        // check if we are in the middle of the box if so, insert the text
+        if n == (height / 2) {
+            let x = (lineLen / 2) - (title.chars().count() as u16 / 2);
+            let goto = term.cursor.goto(x, y);
+            
+            if goto.is_ok() {
+                println!("{}", title);
+            }
+            let x = (lineLen / 2) - (text.chars().count() as u16 / 2);
+            let goto = term.cursor.goto(x, y + 1);
+
+            if goto.is_ok() {
+                print!("{}", text);
+            }
+        }
+
+        let goto = term.cursor.goto(x + lineLen, y);
         
         if goto.is_ok() {
             print!("{}", "*");

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,10 +106,10 @@ fn draw_field(field: &Field<char>, cursor: &TerminalCursor) {
 fn read_direction(input: &mut AsyncReader) -> Option<Direction> {
     if let Some(InputEvent::Keyboard(key)) = input.next() {
         return match key {
-            KeyEvent::Up => Some(Direction::UP),
-            KeyEvent::Down => Some(Direction::UP),
-            KeyEvent::Left => Some(Direction::LEFT),
-            KeyEvent::Right => Some(Direction::RIGHT),
+            KeyEvent::Up => Some(Direction::Up),
+            KeyEvent::Down => Some(Direction::Down),
+            KeyEvent::Left => Some(Direction::Left),
+            KeyEvent::Right => Some(Direction::Right),
             _ => None
         };
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,22 +149,22 @@ fn init(term: &mut Term) -> Bounds {
 }
 
 fn draw_score(term: &mut Term, score: u32) {
-    term.terminal.clear(ClearType::All);
+    let _ = term.terminal.clear(ClearType::All);
 
     // the margin around the box (x, y).
-    const margin: (u16, u16) = (4, 4);
+    const MARGIN: (u16, u16) = (4, 4);
     // the height of the box.
-    const height: u16 = 6;
+    const HEIGHT: u16 = 6;
 
     // the length of the upper border.
-    let lineLen = term.terminal.terminal_size().0 - margin.0;
+    let line_length = term.terminal.terminal_size().0 - MARGIN.0;
     let mut line = String::from("*");
 
     // build the upper border with the specified length.
-    for _ in 0..lineLen {
+    for _ in 0..line_length {
         line += "*";
     }
-    let goto = term.cursor.goto(margin.0 / 2, margin.1 / 2);
+    let goto = term.cursor.goto(MARGIN.0 / 2, MARGIN.1 / 2);
     
     // draw the upper border.
     if goto.is_ok() {
@@ -174,9 +174,9 @@ fn draw_score(term: &mut Term, score: u32) {
     let title = String::from("GAME OVER!");
     let text = format!("Your Score: {}", score);
 
-    for n in 0..height + 1 {
-        let x = margin.0 / 2;
-        let y = margin.1 / 2 + n;
+    for n in 0..HEIGHT + 1 {
+        let x = MARGIN.0 / 2;
+        let y = MARGIN.1 / 2 + n;
         let goto = term.cursor.goto(x, y);
         
         if goto.is_ok() {
@@ -184,14 +184,14 @@ fn draw_score(term: &mut Term, score: u32) {
         }
 
         // check if we are in the middle of the box if so, insert the text
-        if n == (height / 2) {
-            let x = (lineLen / 2) - (title.chars().count() as u16 / 2);
+        if n == (HEIGHT / 2) {
+            let x = (line_length / 2) - (title.chars().count() as u16 / 2);
             let goto = term.cursor.goto(x, y);
             
             if goto.is_ok() {
                 println!("{}", title);
             }
-            let x = (lineLen / 2) - (text.chars().count() as u16 / 2);
+            let x = (line_length / 2) - (text.chars().count() as u16 / 2);
             let goto = term.cursor.goto(x, y + 1);
 
             if goto.is_ok() {
@@ -199,7 +199,7 @@ fn draw_score(term: &mut Term, score: u32) {
             }
         }
 
-        let goto = term.cursor.goto(x + lineLen, y);
+        let goto = term.cursor.goto(x + line_length, y);
         
         if goto.is_ok() {
             print!("{}", "*");
@@ -207,7 +207,7 @@ fn draw_score(term: &mut Term, score: u32) {
     }
     println!();
     
-    term.cursor.move_right(margin.0 / 2);
+    term.cursor.move_right(MARGIN.0 / 2);
     print!("{}", line);
     
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use logic::field::Field;
 mod logic;
 
 struct Bounds {
-    col: u16,
+    col: u16, 
     row: u16
 }
 
@@ -145,7 +145,7 @@ fn init(term: &mut Term) -> Bounds {
         row: height,
     };
 
-    return bounds
+    bounds
 }
 
 fn draw_score(term: &mut Term) {
@@ -168,6 +168,12 @@ fn draw_score(term: &mut Term) {
 
     for n in 0..height {
         let goto = term.cursor.goto(margin.0 / 2, margin.1 / 2 + n);
+        
+        if goto.is_ok() {
+            print!("{}", "*");
+        }
+        let goto = term.cursor.goto((margin.0 / 2) + lineLen, margin.1 / 2 + n);
+        
         if goto.is_ok() {
             print!("{}", "*");
         }


### PR DESCRIPTION
This PR contains the whole implementation of the `draw_score()` function which displays a "Game Over"-Box containing the user's score.

Also, the Rust naming convention for enum variants have been applied to `Direction`.